### PR TITLE
updated epd-fuse installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,20 @@ If cross compiling on a different computer, use these settings `GOARM=5 GOOS=lin
 The repaper fuse driver is required to use this golang library.
 
     # Install fuse driver
-    sudo apt-get install libfuse-dev -y
+    apt-get install libfuse-dev -y
+    # Install fonts
+    apt-get install fonts-freefont-ttf -y
 
+    rm -R /tmp/papirus
     mkdir /tmp/papirus
     cd /tmp/papirus
     git clone https://github.com/repaper/gratis.git
 
-    cd /tmp/papirus/gratis-master/PlatformWithOS
-    make rpi-epd_fuse
-    sudo make rpi-install
-    sudo systemctl start epd-fuse.service
+    cd /tmp/papirus/gratis
+    make rpi EPD_IO=epd_io.h PANEL_VERSION='V231_G2'
+    make rpi-install EPD_IO=epd_io.h PANEL_VERSION='V231_G2'
+    systemctl enable epd-fuse.service
+    systemctl start epd-fuse
 
 ### Get the go-epdfuse project
 


### PR DESCRIPTION
updated epd-fuse installation. This has been updated in our code at https://github.com/PiSupply/PaPiRus but not in the readme. Apologies for that.

You need the panel version and other parameters after the make commands for this to work. Hopefully this should work better with the latest gratis epd-fuse code.

Not familiar with go, but @wmarbut perhaps you could test this from a clean Raspbian install and see if it works properly?