### PR TITLE
Update epdfuse.go

### DIFF
--- a/epdfuse.go
+++ b/epdfuse.go
@@ -73,6 +73,16 @@ func (epd *EpdFuse) WriteImage(img image.Image) error {
 	return epd.Update()
 }
 
+// Write partial image to your PaPiRus display
+func (epd *EpdFuse) WriteImagePartial(img image.Image) error {
+	img = epd.scaleAndPlaceImage(img)
+	err := epd.writeDisplay(goxbm.ToRawXBMBytes(img))
+	if err != nil {
+		return err
+	}
+	return epd.PartialUpdate()
+}
+
 // Force an update of the PaPiRus display
 func (epd *EpdFuse) Update() error {
 	return epd.update(COMMAND_UPDATE)


### PR DESCRIPTION
added a simple WriteImagePartial to do partial updates. If you use this method, you will want to do a full WriteImage every so often to clean up the bits that get missed over time. 

For the application I'm using it in, I do a full WriteImage every minute or so, after 30-45 partial updates.

cheers! (and thanks for your work, it's nice to get away from python for using these e-paper displays)